### PR TITLE
make it work on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Author: [Ali Bajwa](https://www.linkedin.com/in/aliabajwa)
 ##### Pre-requisites:
   - HDP 2.3.x with at least HDFS, YARN, Zookeper, Spark installed. Hive installation is optional. Instructions for older releases available [here](https://github.com/hortonworks-gallery/ambari-zeppelin-service/blob/master/README-22.md)
   - Have 2 ports available and open for zeppelin and its websocket. These will be defaulted to 9995/9996 (but can be configured in Ambari). If using sandbox on VirtualBox, you need to manually forward these.
-  - Maven is required to set up Zeppelin View.
 
 ##### Features:
   - Automates deployment, configuration, management of zeppelin on HDP cluster

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Author: [Ali Bajwa](https://www.linkedin.com/in/aliabajwa)
     - [Configure Zeppelin](https://github.com/hortonworks-gallery/ambari-zeppelin-service#configure-zeppelin)
   - Option 2: [Automated deployment of a fresh HDP cluster that includes Zeppelin (via blueprints)](https://github.com/hortonworks-gallery/ambari-zeppelin-service#option-2-automated-deployment-of-a-fresh-hdp-cluster-that-includes-zeppelin-via-blueprints)
   - Getting started with Zeppelin after deployment:
-    - [Install Ambari view](https://github.com/hortonworks-gallery/ambari-zeppelin-service#install-zeppelin-view)  
+    - [Install Ambari view](https://github.com/hortonworks-gallery/ambari-zeppelin-service#install-zeppelin-view)
     - [Run demo zeppelin notebooks](https://github.com/hortonworks-gallery/ambari-zeppelin-service#use-zeppelin-notebooks)
     - [Zeppelin YARN integration](https://github.com/hortonworks-gallery/ambari-zeppelin-service/blob/master/README.md#zeppelin-yarn-integration)
-  - Other:  
+  - Other:
     - [Remote management](https://github.com/hortonworks-gallery/ambari-zeppelin-service/blob/master/README.md#remote-management)
     - [Remove zeppelin service](https://github.com/hortonworks-gallery/ambari-zeppelin-service#remove-zeppelin-service)
     - [Deploy on clusters without internet access](https://github.com/hortonworks-gallery/ambari-zeppelin-service#deploy-on-clusters-without-internet-access)
@@ -27,11 +27,12 @@ Author: [Ali Bajwa](https://www.linkedin.com/in/aliabajwa)
 ##### Pre-requisites:
   - HDP 2.3.x with at least HDFS, YARN, Zookeper, Spark installed. Hive installation is optional. Instructions for older releases available [here](https://github.com/hortonworks-gallery/ambari-zeppelin-service/blob/master/README-22.md)
   - Have 2 ports available and open for zeppelin and its websocket. These will be defaulted to 9995/9996 (but can be configured in Ambari). If using sandbox on VirtualBox, you need to manually forward these.
+  - Maven is required to set up Zeppelin View.
 
 ##### Features:
   - Automates deployment, configuration, management of zeppelin on HDP cluster
   - Runs zeppelin in yarn-client mode (instead of standalone). Why is this important?
-    - *Multi-tenancy*: The service autodetects and configures Zeppelin to point to default Spark YARN queue. Users can use this, in conjunction with the [Capacity scheduler/YARN Queue Manager view](http://hortonworks.com/blog/hortonworks-data-platform-2-3-delivering-transformational-outcomes/), to set what percentage of the clusters resources get allocated to Spark.  
+    - *Multi-tenancy*: The service autodetects and configures Zeppelin to point to default Spark YARN queue. Users can use this, in conjunction with the [Capacity scheduler/YARN Queue Manager view](http://hortonworks.com/blog/hortonworks-data-platform-2-3-delivering-transformational-outcomes/), to set what percentage of the clusters resources get allocated to Spark.
     - *Security*: Ranger YARN plugin can be used to setup authorization policies on which users/groups are allowed to submit spark jobs. Both allowed requests and rejections can also be audited in Ranger.
   - Supports both default HDP Spark version (e.g. 1.3.1 with HDP 2.3.0 or 1.4.1 with HDP 2.3.2) as well as custom installed Spark versions e.g. [HDP Spark 1.5.1 TP on HDP 2.3.2](http://hortonworks.com/hadoop-tutorial/apache-spark-1-5-1-technical-preview-with-hdp-2-3/)
   - Automates deployment of Ambari view to bring up Zeppelin webapp (requires manual ambari-server restart)
@@ -42,10 +43,10 @@ Author: [Ali Bajwa](https://www.linkedin.com/in/aliabajwa)
   - Use Ambari APIs to autodetect and configure Zeppelin interpreter to point to:
     - HiveServer2 to enable Zeppelin hive interpreter (if Hive is installed)
     - Hive metastore so Spark commands can access Hive tables out of the box (if Hive is installed)
-    - Phoenix JDBC connect url to enable Zeppelin Phoenix interpreter (if Hbase is installed). 
+    - Phoenix JDBC connect url to enable Zeppelin Phoenix interpreter (if Hbase is installed).
   - Offline mode: can manually copy tar to /tmp/zeppelin.tar.gz to allow service to be installed on clusters without internet access
   - Deploy using steps below or via [Ambari Store view](https://github.com/jpplayer/amstore-view)
-  - (11/29/15): changed to allow automated install on HDP via Ambari Blueprint  
+  - (11/29/15): changed to allow automated install on HDP via Ambari Blueprint
 
 
 ##### Limitations:
@@ -57,12 +58,12 @@ Author: [Ali Bajwa](https://www.linkedin.com/in/aliabajwa)
 
 ##### Known issues:
   - [Error running hive queries on Zeppelin setup with Spark 1.4/1.5](https://community.hortonworks.com/questions/4905/error-while-running-hive-queries-from-zeppelin.html)
-    
+
 ##### Testing:
   - These steps were tested on:
     - HDP 2.3.2 cluster installed via Ambari 2.1.2 (comes with Spark 1.4.1) on Centos 6. Also tested with manually installed Spark 1.5.1 from [HDP Tech preview](https://hortonworks.com/hadoop-tutorial/apache-spark-1-5-1-technical-preview-with-hdp-2-3/)
     - Latest HDP 2.3.2 sandbox (comes with Spark 1.4.1) on Centos 6. Also tested with manually installed Spark 1.5.1 from [HDP Tech preview](https://hortonworks.com/hadoop-tutorial/apache-spark-1-5-1-technical-preview-with-hdp-2-3/)
-  
+
 ##### Videos (from HDP 2.2.4.2):
   - [How to setup zeppelin service](https://www.dropbox.com/s/9s122qbjilw5d2u/zeppelin-1-setup.mp4?dl=0)
   - [How to setup zeppelin view and run sample notebooks](https://www.dropbox.com/s/skhudcy89s7qho1/zeppelin-2-view-demo.mp4?dl=0)
@@ -73,10 +74,10 @@ Author: [Ali Bajwa](https://www.linkedin.com/in/aliabajwa)
 - There are two options to deploy Zeppelin from Ambari:
   - Option 1: [Deploy Zeppelin on existing cluster](https://github.com/hortonworks-gallery/ambari-zeppelin-service#option-1-deploy-zeppelin-on-existing-cluster)
   - Option 2: [Automated deployment of a fresh HDP cluster that includes Zeppelin (via blueprints)](https://github.com/hortonworks-gallery/ambari-zeppelin-service#option-2-automated-deployment-of-a-fresh-hdp-cluster-that-includes-zeppelin-via-blueprints)
-  
+
 -------------------
 
-#### Option 1: Deploy Zeppelin on existing cluster:  
+#### Option 1: Deploy Zeppelin on existing cluster:
 
 ##### Setup Pre-requisites:
 
@@ -85,13 +86,13 @@ Author: [Ali Bajwa](https://www.linkedin.com/in/aliabajwa)
 - Now start the VM
 - After it boots up, find the IP address of the VM and add an entry into your machines hosts file e.g.
 ```
-192.168.191.241 sandbox.hortonworks.com sandbox    
+192.168.191.241 sandbox.hortonworks.com sandbox
 ```
 - Connect to the VM via SSH (password hadoop)
 ```
 ssh root@sandbox.hortonworks.com
 ```
-- If you deployed in a VirtualBox Sandbox environment, enable port forwarding on ports 9995 and 9996. If you don't enable port 9996, the Zeppelin UI/Ambari View shows disconnected on the upper right and none of the default tutorials are visible. 
+- If you deployed in a VirtualBox Sandbox environment, enable port forwarding on ports 9995 and 9996. If you don't enable port 9996, the Zeppelin UI/Ambari View shows disconnected on the upper right and none of the default tutorials are visible.
 
 - Ensure Spark is installed. If not, use Add service wizard to install Spark. You can also bring down services that are not used by this tutorial (like Oozie/Falcon) and, additionally, install Hive if you want to leverage from Hive tables in Zeppelin Notebook.
 
@@ -125,7 +126,7 @@ sed -i /spark.yarn.services/s/^/#/ /usr/hdp/2.3.2.1-12/spark/conf/spark-defaults
 - To deploy the Zeppelin service, run below on ambari server
 ```
 VERSION=`hdp-select status hadoop-client | sed 's/hadoop-client - \([0-9]\.[0-9]\).*/\1/'`
-sudo git clone https://github.com/hortonworks-gallery/ambari-zeppelin-service.git   /var/lib/ambari-server/resources/stacks/HDP/$VERSION/services/ZEPPELIN   
+sudo git clone https://github.com/hortonworks-gallery/ambari-zeppelin-service.git   /var/lib/ambari-server/resources/stacks/HDP/$VERSION/services/ZEPPELIN
 ```
 
 - Restart Ambari
@@ -138,7 +139,7 @@ sudo service ambari-server restart
 ```
 - Once Ambari comes back up and the services turn green, you can click on 'Add Service' from the 'Actions' dropdown menu in the bottom left of the Ambari dashboard:
 
-On bottom left -> Actions -> Add service -> check Zeppelin service -> Next -> Next -> Next -> Deploy. 
+On bottom left -> Actions -> Add service -> check Zeppelin service -> Next -> Next -> Next -> Deploy.
 ![Image](../master/screenshots/install-1.png?raw=true)
 ![Image](../master/screenshots/install-2.png?raw=true)
 ![Image](../master/screenshots/install-3.png?raw=true)
@@ -151,13 +152,13 @@ On bottom left -> Actions -> Add service -> check Zeppelin service -> Next -> Ne
 - There are three sections of configuration:
   - i) Advanced zeppelin-ambari-config: Parameters specific to Ambari service only (will not be written to zeppelin-site.xml or zeppelin-env.sh)
     - install dir: Local dir under which to install component
-    - setup prebuilt: If true, will download previously built package (instead of building from source). To compile from source instead, set to false. If cluster does not have internet access, manually copy the tar.gz to /tmp/zeppelin.tar.gz on Ambari server and set this property to true. 
+    - setup prebuilt: If true, will download previously built package (instead of building from source). To compile from source instead, set to false. If cluster does not have internet access, manually copy the tar.gz to /tmp/zeppelin.tar.gz on Ambari server and set this property to true.
     - setup view: Whether the Zeppelin view should be compiled. Set to false if cluster does not have internet access
     - spark jar dir: Shared location where zeppelin spark jar will be copied to. Should be accesible by all cluster nodes. Its possible to manually host this on object store. For example to point this to WASB, you can set this to `wasb:///apps/zeppelin`
     - executor memory: Executor memory to use (e.g. 512m or 1g)
     - temp file: Temporary file where pre-built package will be downloaded to. If your env has limited space under /tmp, change this to different location. In this case you must ensure that the zeppelin user must be able to write to this location.
     - public name: This is used to setup the Ambari view for Zeppelin. Set this to the public host/IP of zeppelin node (which must must be reachable from your local machine). If installing on sandbox (or local VM), change this to the IP address of VM. If installing on cloud, set this to public name/IP of zeppelin node. Alternatively, if you already have a local hosts file entry for the internal hostname of the zeppelin node (e.g. sandbox.hortonworks.com), you can leave this empty - it will default to internal hostname
-    - spark home: Spark home directory. Defaults to the Spark that comes with HDP (e.g. 1.4.1 with HDP 2.3.2). To point Zeppelin to different Spark build, change this to location of where you downloaded Spark to (e.g. /usr/hdp/2.3.2.1-12/spark/). The service will detect the version of spark installed here (via RELEASE file) and pull appropriate prebuilt Zeppelin package  
+    - spark home: Spark home directory. Defaults to the Spark that comes with HDP (e.g. 1.4.1 with HDP 2.3.2). To point Zeppelin to different Spark build, change this to location of where you downloaded Spark to (e.g. /usr/hdp/2.3.2.1-12/spark/). The service will detect the version of spark installed here (via RELEASE file) and pull appropriate prebuilt Zeppelin package
     - python packages: (Optional) (CentOS only) - Set this to true to install numpy scipy pandas scikit-learn. Note that selecting this option will increase the install time by 5-10 min depending on your connection. Can leave false if not needed, but note that the sample pyspark notebook will not work without it
 
 
@@ -171,11 +172,11 @@ On bottom left -> Actions -> Add service -> check Zeppelin service -> Next -> Ne
   - ii) Advanced zeppelin-config: Used to populate [zeppelin-site.xml](https://github.com/apache/incubator-zeppelin/blob/master/conf/zeppelin-site.xml.template)
     - If needed you can modify the zeppelin ports here (default to 9995,9996)
 ![Image](../master/screenshots/install-5.png?raw=true)
-  
+
   - iii) Advanced zeppelin-env: Used to populate [zeppelin-env.sh](https://github.com/apache/incubator-zeppelin/blob/master/conf/zeppelin-env.sh.template). See [Zeppelin docs](https://zeppelin.incubator.apache.org/docs/install/install.html) for more info
-    - Under `export ZEPPELIN_JAVA_OPTS` notice that the Spark jobs will by default be sent to the default spark queue `-Dspark.yarn.queue={{spark_queue}}`. 
+    - Under `export ZEPPELIN_JAVA_OPTS` notice that the Spark jobs will by default be sent to the default spark queue `-Dspark.yarn.queue={{spark_queue}}`.
     - To have Zeppelin jobs submitted to a different queue instead, just change to `-Dspark.yarn.queue=my_zeppelin_queuename` (based on your queue name)
-![Image](../master/screenshots/install-6.png?raw=true)      
+![Image](../master/screenshots/install-6.png?raw=true)
 
 
 - Click Next to accept defaults...
@@ -186,7 +187,7 @@ Note that:
 
 - The default mode of the service sets up Zeppelin in yarn-client mode by downloading a tarball of precompiled bits (ETA: < 5min)
 
-- (Optional) To instead pull/compile the latest Zeppelin code from the [git page](https://github.com/apache/incubator-zeppelin) (ETA: < 40min depending on internet connection):  
+- (Optional) To instead pull/compile the latest Zeppelin code from the [git page](https://github.com/apache/incubator-zeppelin) (ETA: < 40min depending on internet connection):
   - While adding zeppelin service, in the configuration step of the wizard:
     - set zeppelin.setup.prebuilt to false
 
@@ -227,13 +228,13 @@ git clone https://github.com/hortonworks-gallery/ambari-zeppelin-service.git /va
 - Edit the `/var/lib/ambari-server/resources/stacks/HDP/2.3/role_command_order.json` file to include below:
 ```
   "ZEPPELIN_MASTER-START": ["NAMENODE-START", "DATANODE-START"],
-```    
+```
   - Note that comma at the end. If you insert the above as the last line, you need to remove the comma
 
 - Restart Ambari
 ```
 service ambari-server restart
-service ambari-agent restart    
+service ambari-agent restart
 ```
 
 - Confirm 4 agents were registered and agent remained up
@@ -296,7 +297,7 @@ vi blueprint-zeppelin.json
 ```
   - if deploying on public cloud, you will want to add `"zeppelin.host.publicname":"<public IP or hostname of zeppelin node>"` so the Zeppelin Ambari view is pointing to external hostname (instead of the internal name, which is the default)
 
-  
+
 
 - Upload selected blueprint and download a sample cluster.json that provides your host FQDN's. Modify the host FQDN's in the cluster.json file your own env. Finally deploy cluster and call it zeppelinCluster
 ```
@@ -322,7 +323,7 @@ vi cluster.json
 ```
 curl -u admin:admin -H  X-Requested-By:ambari http://localhost:8080/api/v1/clusters/zeppelinCluster -d @cluster.json
 ```
-- You can monitor the progress of the deployment via Ambari (e.g. http://node1:8080). 
+- You can monitor the progress of the deployment via Ambari (e.g. http://node1:8080).
 
 - Once install completes, you will have a 4 node HDP cluster including Zeppelin
 
@@ -351,10 +352,10 @@ vi src/main/resources/index.html
 
 mvn clean package
 
-#Now copy the zeppelin view jar from `/home/zeppelin/zeppelin-view/target/zeppelin-view-1.0-SNAPSHOT.jar` on zeppelin node, to `/var/lib/ambari-server/resources/views/` dir on Ambari server node. 
+#Now copy the zeppelin view jar from `/home/zeppelin/zeppelin-view/target/zeppelin-view-1.0-SNAPSHOT.jar` on zeppelin node, to `/var/lib/ambari-server/resources/views/` dir on Ambari server node.
 
 #Then restart Ambari server
-  ``` 
+  ```
 
 #### Use zeppelin notebooks
 
@@ -363,9 +364,9 @@ mvn clean package
 
 - There should be a few sample notebooks created. Select the Hive one (*make sure Hive service is installed and started first*)
 - On first launch of a notebook, you will the "Interpreter Binding" settings will be displayed. You will need to click "Save" under the interpreter order.
-![Image](../master/screenshots/interpreter-binding.png?raw=true)    
+![Image](../master/screenshots/interpreter-binding.png?raw=true)
 
-- Now you will see the list of executable cells laid out in a sequence 
+- Now you will see the list of executable cells laid out in a sequence
 ![Image](../master/screenshots/install-9.png?raw=true)
 
 - Execute the cells one by one, by clicking the 'Play' (triangular) button on top right of each cell or just highlight a cell then press Shift-Enter
@@ -378,10 +379,10 @@ mvn clean package
  tail -f /var/log/zeppelin/zeppelin-zeppelin-sandbox.hortonworks.com.out
 ```
 - Now try the AON Demo for an example of displaying data on a map
-![Image](../master/screenshots/map-notebook.png?raw=true)  
+![Image](../master/screenshots/map-notebook.png?raw=true)
 
   - Once the Spark notebook has completed, you can restart the Spark interpreter via 'Interpreter' tab to free up cluster resources
-  
+
 - Start Hbase via Ambari and run the Phoenix notebook (*make sure HBase is started and Phoenix is enabled/installed first*)
   - To check if Phoenix client is installed, run below on Zeppelin node and ensure below dir is not empty
   ```
@@ -390,27 +391,27 @@ mvn clean package
   - If Phoenix is not installed, follow the below to install:
     - In Ambari, under Hbase > Configs > Settings > Phoenix SQL > Enabled
     - Stop Hbase and then start Hbase to invoke the Phoenix install
-    
-  - Once setup, you should be able to run through the sample Phoenix notebook  
-![Image](../master/screenshots/phoenix-notebook.png?raw=true)  
+
+  - Once setup, you should be able to run through the sample Phoenix notebook
+![Image](../master/screenshots/phoenix-notebook.png?raw=true)
 
 - Other things to try
   - Access hive tables from SparkSql
     - If Hive metastore is installed/started, you should be able to run queries against Hive tables from SparkSql
-    
+
   - If you installed the optional python packages, you can run the pyspark notebook
-  
-  - Test settings by checking the spark version and spark home, python path env vars. 
+
+  - Test settings by checking the spark version and spark home, python path env vars.
 ```
 sc.version
 sc.getConf.get("spark.home")
 System.getenv().get("PYTHONPATH")
 System.getenv().get("SPARK_HOME")
-``` 
- 
+```
+
   - If you are using Spark 1.5, `sc.version` should return `String = 1.5.1` and `SPARK_HOME` should be `/usr/hdp/2.3.2.1-12/spark/` (or whatever you set)
-  - If you are using Spark 1.3 or 1.4, `sc.version` should return appropriately and `SPARK_HOME` should be `/usr/hdp/current/spark-client/` 
-    
+  - If you are using Spark 1.3 or 1.4, `sc.version` should return appropriately and `SPARK_HOME` should be `/usr/hdp/current/spark-client/`
+
 
 - To enable Dependency loading (e.g. loading jars or maven repo/artifacts) or create a form in your notebook, see [Zeppelin docs](https://zeppelin.incubator.apache.org/docs/interpreter/spark.html#dependencyloading)
 
@@ -420,17 +421,17 @@ System.getenv().get("SPARK_HOME")
   - Spark (and Tez) jobs launched by Zeppelin are running on YARN
   - Assuming you setup the spark queue above, Spark job should be running on *spark* queue
   - Hive/Tez job is running on *default* queue
-  
+
 ![Image](../master/screenshots/RM-UI.png?raw=true)
 
 - To access the Spark UI, you can click on the ApplicationMaster link in YARN UI:
 
 ![Image](../master/screenshots/spark-UI.png?raw=true)
 
-  - Use the scheduler link to validate the proportion of the cluster used by Spark/Tez. For example, if you setup the Spark YARN queue as above, when only Spark is running, the UI will show Spark taking up 89% of the cluster  
-![Image](../master/screenshots/RM-UI-2.png?raw=true)  
+  - Use the scheduler link to validate the proportion of the cluster used by Spark/Tez. For example, if you setup the Spark YARN queue as above, when only Spark is running, the UI will show Spark taking up 89% of the cluster
+![Image](../master/screenshots/RM-UI-2.png?raw=true)
   - The Ambari metrics on the main Ambari dashboard will show the same:
-![Image](../master/screenshots/Ambari-YARN-metric.png?raw=true)  
+![Image](../master/screenshots/Ambari-YARN-metric.png?raw=true)
 
   - You can also use this YARN UI for troubleshooting hanging jobs. For example if Hive job is stuck waiting for Spark to give up YARN resources (or vice versa), you can restart the Spark interpreter via Zeppelin before running the Hive query
 
@@ -438,11 +439,11 @@ System.getenv().get("SPARK_HOME")
   - For more details: see sample steps to [setup Ranger's YARN plugin](https://github.com/abajwa-hw/security-workshops/blob/master/Setup-ranger-23.md#setup-yarn-plugin-for-ranger) and [setup YARN queue and Ranger policy](https://github.com/abajwa-hw/security-workshops/blob/master/Setup-ranger-23.md#yarn-audit-exercises-in-ranger) on an Ambari installed HDP 2.3 cluster.
   - Note: on the current version of HDP 2.3 sandbox, Ranger YARN plugin has not been setup
   - Screenshot of how you would create a Ranger policy for 'zeppelin' user to access 'spark' YARN queue:
-  
-![Image](../master/screenshots/ranger-yarn-policy.png?raw=true) 
-  
+
+![Image](../master/screenshots/ranger-yarn-policy.png?raw=true)
+
 - Don't want to take our word for the benefits of Spark on YARN? Check [this Spark Summit talk by Kelvin Chi (Uber)](https://www.youtube.com/watch?v=vdwot545LKA)
-  
+
 ---------------------
 
 #### Remote management
@@ -467,10 +468,10 @@ curl -u admin:$PASSWORD -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo"
 
 #### Remove zeppelin service
 
-- In case you need to remove the Zeppelin service: 
+- In case you need to remove the Zeppelin service:
 
   - Stop the service and delete it. Then restart Ambari
-  
+
 ```
 export SERVICE=ZEPPELIN
 export PASSWORD=admin
@@ -488,8 +489,8 @@ curl -u admin:$PASSWORD -i -H 'X-Requested-By: ambari' -X DELETE http://$AMBARI_
 
 service ambari-server restart
 ```
-  - Remove artifacts 
-  
+  - Remove artifacts
+
 ```
 rm -rf /opt/incubator-zeppelin
 rm -rf /var/log/zeppelin*
@@ -505,17 +506,17 @@ service ambari-server restart
 
 ----------------
 
-#### Deploy on clusters without internet access 
+#### Deploy on clusters without internet access
 
 - Get appropriate zeppelin package copied to /tmp/zeppelin.tar.gz on Ambari server node (this location is configurable via zeppelin.temp.file property)
-```   
+```
 #package built for spark 1.3.1 packaged with HDP 2.3.0
 #PACKAGE=https://www.dropbox.com/s/k4dvmmxzd08q3h9/zeppelin-0.5.5-incubating-SNAPSHOT-repackage.tar.gz
 
 #or package built for spark 1.4.1 packaged with HDP 2.3.2
 #PACKAGE=https://www.dropbox.com/s/nwpv7dr1a724vtv/zeppelin-0.5.5-incubating-HDP232.tar.gz
 
-#or package built for HDP spark 1.5.1 TP 
+#or package built for HDP spark 1.5.1 TP
 #PACKAGE=https://dl.dropboxusercontent.com/u/114020/zeppelin-snapshots/spark-1.5.1TP-HDP2.3.2/zeppelin-0.5.5-incubating-spark151-tp.tar.gz
 
 wget $PACKAGE -O /tmp/zeppelin.tar.gz
@@ -534,6 +535,6 @@ unzip /tmp/ZEPPELIN.zip -d /var/lib/ambari-server/resources/stacks/HDP/$VERSION/
   - Advanced zeppelin-ambari-config
     - zeppelin.setup.view = false (this ensures it does not try to build the view or download sample notebooks)
     - zeppelin.spark.home = /your/spark/home (only needs to be changed if you installed your own spark version)
-    
+
 - Proceed with remaining screens and click Deploy
 

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -24,10 +24,10 @@
               <osSpecific>
                 <osFamily>redhat6</osFamily>
                 <packages>
-                   <package><name>nss</name></package>                    
-                   <package><name>git</name></package>    
-                   <package><name>java-1.7.0-openjdk-devel</name></package>  
-                   <package><name>apache-maven-3.2*</name></package>                                           
+                   <package><name>nss</name></package>
+                   <package><name>git</name></package>
+                   <package><name>java-1.7.0-openjdk-devel</name></package>
+                   <package><name>apache-maven-3.2*</name></package>
                 </packages>
               </osSpecific>
               <osSpecific>
@@ -38,17 +38,24 @@
                    <package><name>java-1.7.0-openjdk-devel</name></package>
                    <package><name>maven</name></package>
                 </packages>
-              </osSpecific>              
+              </osSpecific>
              <osSpecific>
                 <osFamily>ubuntu12</osFamily>
                 <packages>
-                   <package><name>git</name></package>    
-                   <package><name>maven</name></package>                                           
+                   <package><name>git</name></package>
+                   <package><name>maven</name></package>
                 </packages>
-              </osSpecific>                               
-            </osSpecifics> 
+              </osSpecific>
+             <osSpecific>
+                <osFamily>ubuntu14</osFamily>
+                <packages>
+                   <package><name>git</name></package>
+                   <package><name>maven</name></package>
+                </packages>
+              </osSpecific>
+            </osSpecifics>
       	    <configuration-dependencies>
-        	<config-type>zeppelin-ambari-config</config-type>      	    
+        	<config-type>zeppelin-ambari-config</config-type>
         	<config-type>zeppelin-config</config-type>
       	    </configuration-dependencies>
             <restartRequiredAfterChange>false</restartRequiredAfterChange>

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -1,6 +1,11 @@
+# encoding=utf8
+
 import sys, os, pwd, grp, signal, time, glob
 from resource_management import *
 from subprocess import call
+
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 class Master(Script):
   def install(self, env):
@@ -9,12 +14,12 @@ class Master(Script):
     import status_params
 
     env.set_params(params)
-          
+
     #location of prebuilt package from april 2015
     snapshot_package_12='https://www.dropbox.com/s/nhv5j42qsybldh4/zeppelin-0.5.0-SNAPSHOT.tar.gz'
 
 
-    #location of prebuilt package from Oct 23 2015 using spark 1.3.1 that comes with HDP 2.3.0    
+    #location of prebuilt package from Oct 23 2015 using spark 1.3.1 that comes with HDP 2.3.0
     snapshot_package_13='https://www.dropbox.com/s/k4dvmmxzd08q3h9/zeppelin-0.5.5-incubating-SNAPSHOT-repackage.tar.gz'
 
     #location of prebuilt 0.5.5 package compiled using HDP Spark 1.4.1 TP that comes with HDP 2.3.2
@@ -22,23 +27,23 @@ class Master(Script):
 
     #location of prebuilt 0.5.5 package compiled using HDP Spark 1.5.1 TP
     snapshot_package_15='https://dl.dropboxusercontent.com/u/114020/zeppelin-snapshots/spark-1.5.1TP-HDP2.3.2/zeppelin-0.5.5-incubating-spark151-tp.tar.gz'
-    
-                
+
+
     Execute('find '+params.service_packagedir+' -iname "*.sh" | xargs chmod +x')
 
     #Create user and group if they don't exist
-    self.create_linux_user(params.zeppelin_user, params.zeppelin_group)                              
+    self.create_linux_user(params.zeppelin_user, params.zeppelin_group)
     #self.create_hdfs_user(params.zeppelin_user, params.spark_jar_dir)
 
-    #remove /opt/incubator-zeppelin if already exists        
+    #remove /opt/incubator-zeppelin if already exists
     Execute('rm -rf ' + params.zeppelin_dir, ignore_failures=True)
-        
+
     #create the log, pid, zeppelin dirs
     Directory([params.zeppelin_pid_dir, params.zeppelin_log_dir, params.zeppelin_dir],
             owner=params.zeppelin_user,
             group=params.zeppelin_group,
             recursive=True
-    )   
+    )
 
     File(params.zeppelin_log_file,
             mode=0644,
@@ -46,9 +51,9 @@ class Master(Script):
             group=params.zeppelin_group,
             content=''
     )
-             
+
     Execute('echo spark_version:' + params.spark_version + ' detected for spark_home: ' + params.spark_home + ' >> ' + params.zeppelin_log_file)
-    
+
     #if on CentOS and python packages specified, install them
     if params.install_python_packages:
       distribution = platform.linux_distribution()[0].lower()
@@ -57,7 +62,7 @@ class Master(Script):
 
       Execute('echo distribution is: ' + distribution)
       Execute('echo version is: ' + version)
-      
+
       if distribution.startswith('centos'):
         if version.startswith('7'):
           Execute('echo Installing python packages for Centos 7')
@@ -66,11 +71,11 @@ class Master(Script):
           Execute('pip install --user --install-option="--prefix=" -U scikit-learn')
         if version.startswith('6'):
           Execute('echo Installing python packages for Centos 6')
-          Execute('yum install -y python-devel python-nose python-setuptools gcc gcc-gfortran gcc-c++ blas-devel lapack-devel atlas-devel') 
-          Execute('easy_install pip', ignore_failures=True)      
-          Execute('pip install numpy scipy pandas scikit-learn')      
-        
-    #User selected option to use prebuilt zeppelin package 
+          Execute('yum install -y python-devel python-nose python-setuptools gcc gcc-gfortran gcc-c++ blas-devel lapack-devel atlas-devel')
+          Execute('easy_install pip', ignore_failures=True)
+          Execute('pip install numpy scipy pandas scikit-learn')
+
+    #User selected option to use prebuilt zeppelin package
     if params.setup_prebuilt:
 
       #choose appropriate package based on spark version passes in by user
@@ -79,13 +84,13 @@ class Master(Script):
         snapshot_package = snapshot_package_14
       elif params.spark_version == '1.5':
         Execute('echo Processing with zeppelin tar compiled with spark 1.5')
-        snapshot_package = snapshot_package_15        
+        snapshot_package = snapshot_package_15
       elif params.spark_version == '1.3':
         Execute('echo Processing with zeppelin tar compiled with spark 1.3')
         snapshot_package = snapshot_package_13
       elif params.spark_version == '1.2':
         Execute('echo Processing with zeppelin tar compiled with spark 1.2')
-        snapshot_package = snapshot_package_12        
+        snapshot_package = snapshot_package_12
       else:
         Execute('echo Unrecognized spark version: ' + params.spark_version + ' defaulting to 1.3')
         snapshot_package = snapshot_package_13
@@ -93,11 +98,11 @@ class Master(Script):
       #install maven as root
       if params.setup_view:
         Execute('echo Installing packages')
-        
-        #Install maven repo if needed      
+
+        #Install maven repo if needed
         self.install_mvn_repo()
         # Install packages listed in metainfo.xml
-        self.install_packages(env)    
+        self.install_packages(env)
 
 
       #Fetch and unzip snapshot build, if no cached zeppelin tar package exists on Ambari server node
@@ -105,62 +110,62 @@ class Master(Script):
         Execute('wget '+snapshot_package+' -O '+params.temp_file+' -a '  + params.zeppelin_log_file, user=params.zeppelin_user)
       Execute('tar -zxvf '+params.temp_file+' -C ' + params.zeppelin_dir + ' >> ' + params.zeppelin_log_file, user=params.zeppelin_user)
       Execute('mv '+params.zeppelin_dir+'/*/* ' + params.zeppelin_dir, user=params.zeppelin_user)
-          
-      
+
+
       #update the configs specified by user
       self.configure(env)
-      
+
       #run setup_snapshot.sh
       Execute(format("{service_packagedir}/scripts/setup_snapshot.sh {zeppelin_dir} {hive_metastore_host} {hive_metastore_port} {zeppelin_host} {zeppelin_port} {setup_view}  >> {zeppelin_log_file}"), user=params.zeppelin_user)
 
       #if zeppelin installed on ambari server, copy view jar into ambari views dir
       if params.setup_view:
         if params.ambari_host == params.zeppelin_internalhost and not os.path.exists('/var/lib/ambari-server/resources/views/zeppelin-view-1.0-SNAPSHOT.jar'):
-          Execute('echo "Copying zeppelin view jar to ambari views dir"')      
+          Execute('echo "Copying zeppelin view jar to ambari views dir"')
           Execute('cp /home/'+params.zeppelin_user+'/zeppelin-view/target/*.jar /var/lib/ambari-server/resources/views')
 
 
       Execute('cp ' + params.zeppelin_dir+'/interpreter/spark/dep/zeppelin-spark-dependencies-*.jar /tmp', user=params.zeppelin_user)
-      
+
     else:
       #User selected option to build zeppelin from source
-       
+
       if params.setup_view:
         #Install maven repo if needed
-        self.install_mvn_repo()      
+        self.install_mvn_repo()
         # Install packages listed in metainfo.xml
-        self.install_packages(env)    
-    
+        self.install_packages(env)
+
       #Execute('yum -y install java-1.7.0-openjdk-devel >> ' + params.zeppelin_log_file)
       #if not os.path.exists('/root/.m2'):
-      #  os.makedirs('/root/.m2')     
+      #  os.makedirs('/root/.m2')
       #Execute('cp '+params.service_packagedir+'/files/settings.xml /root/.m2/')
-      
+
       Execute('echo Compiling zeppelin from source')
       Execute('cd '+params.install_dir+'; git clone https://github.com/apache/incubator-zeppelin  >> ' + params.zeppelin_log_file)
       Execute('chown -R ' + params.zeppelin_user + ':' + params.zeppelin_group + ' ' + params.zeppelin_dir)
       #Execute('cd '+params.install_dir+'/incubator-zeppelin; git checkout -b branch-0.5;')
-      
+
       #update the configs specified by user
       self.configure(env)
-            
+
       Execute('cd '+params.zeppelin_dir+'; mvn -Phadoop-2.6 -Dhadoop.version=2.7.1 -Pspark-'+params.spark_version+' -Ppyspark -Pyarn clean package -P build-distr -DskipTests >> ' + params.zeppelin_log_file, user=params.zeppelin_user)
-            
+
       #run setup_snapshot.sh
       Execute(format("{service_packagedir}/scripts/setup_snapshot.sh {zeppelin_dir} {hive_metastore_host} {hive_metastore_port} {zeppelin_host} {zeppelin_port} {setup_view}  >> {zeppelin_log_file}"), user=params.zeppelin_user)
 
       #if zeppelin installed on ambari server, copy view jar into ambari views dir
       if params.setup_view:
         if params.ambari_host == params.zeppelin_internalhost and not os.path.exists('/var/lib/ambari-server/resources/views/zeppelin-view-1.0-SNAPSHOT.jar'):
-          Execute('echo "Copying zeppelin view jar to ambari views dir"')      
+          Execute('echo "Copying zeppelin view jar to ambari views dir"')
           Execute('cp /home/'+params.zeppelin_user+'/zeppelin-view/target/*.jar /var/lib/ambari-server/resources/views')
 
 
   #def install_el6_packages(self, params):
     #Execute('curl -o /etc/yum.repos.d/epel-apache-maven.repo https://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo')
-    #Execute('yum -y install git >> ' + params.zeppelin_log_file)          
-    #Execute('yum -y install apache-maven >> ' + params.zeppelin_log_file)        
-    
+    #Execute('yum -y install git >> ' + params.zeppelin_log_file)
+    #Execute('yum -y install apache-maven >> ' + params.zeppelin_log_file)
+
   def create_linux_user(self, user, group):
     try: pwd.getpwnam(user)
     except KeyError: Execute('adduser ' + user)
@@ -171,57 +176,57 @@ class Master(Script):
     Execute('hadoop fs -mkdir -p /user/'+user, user='hdfs', ignore_failures=True)
     Execute('hadoop fs -chown ' + user + ' /user/'+user, user='hdfs')
     Execute('hadoop fs -chgrp ' + user + ' /user/'+user, user='hdfs')
-    
+
     Execute('hadoop fs -mkdir -p '+spark_jar_dir, user='hdfs', ignore_failures=True)
     Execute('hadoop fs -chown ' + user + ' ' + spark_jar_dir, user='hdfs')
-    Execute('hadoop fs -chgrp ' + user + ' ' + spark_jar_dir, user='hdfs')    
+    Execute('hadoop fs -chgrp ' + user + ' ' + spark_jar_dir, user='hdfs')
 
-  
+
 
   def configure(self, env):
     import params
     import status_params
     env.set_params(params)
     env.set_params(status_params)
-    
+
     #write out zeppelin-site.xml
     XmlConfig("zeppelin-site.xml",
             conf_dir = params.conf_dir,
             configurations = params.config['configurations']['zeppelin-config'],
             owner=params.zeppelin_user,
             group=params.zeppelin_group
-    ) 
+    )
     #write out zeppelin-env.sh
     env_content=InlineTemplate(params.zeppelin_env_content)
-    File(format("{params.conf_dir}/zeppelin-env.sh"), content=env_content, owner=params.zeppelin_user, group=params.zeppelin_group) # , mode=0777)    
-    
+    File(format("{params.conf_dir}/zeppelin-env.sh"), content=env_content, owner=params.zeppelin_user, group=params.zeppelin_group) # , mode=0777)
+
 
   def stop(self, env):
     import params
-    import status_params    
+    import status_params
     #self.configure(env)
     Execute (params.zeppelin_dir+'/bin/zeppelin-daemon.sh stop >> ' + params.zeppelin_log_file, user=params.zeppelin_user)
- 
-      
+
+
   def start(self, env):
     import params
     import status_params
-    self.configure(env) 
-    
+    self.configure(env)
+
     first_setup=False
-    
+
     #cleanup temp dirs
-    note_osx_dir=params.notebook_dir+'/__MACOSX'   
+    note_osx_dir=params.notebook_dir+'/__MACOSX'
     if os.path.exists(note_osx_dir):
       Execute('rm -rf ' + note_osx_dir)
-    
-        
+
+
     if glob.glob('/tmp/zeppelin-spark-dependencies-*.jar') and os.path.exists(glob.glob('/tmp/zeppelin-spark-dependencies-*.jar')[0]):
         first_setup=True
         self.create_hdfs_user(params.zeppelin_user, params.spark_jar_dir)
-        Execute ('hadoop fs -put /tmp/zeppelin-spark-dependencies-*.jar ' + params.spark_jar, user=params.zeppelin_user, ignore_failures=True) 
+        Execute ('hadoop fs -put /tmp/zeppelin-spark-dependencies-*.jar ' + params.spark_jar, user=params.zeppelin_user, ignore_failures=True)
         Execute ('rm /tmp/zeppelin-spark-dependencies-*.jar')
-    
+
     Execute (params.zeppelin_dir+'/bin/zeppelin-daemon.sh start >> ' + params.zeppelin_log_file, user=params.zeppelin_user)
     pidfile=glob.glob(status_params.zeppelin_pid_dir + '/zeppelin-'+params.zeppelin_user+'*.pid')[0]
     Execute('echo pid file is: ' + pidfile, user=params.zeppelin_user)
@@ -230,15 +235,15 @@ class Master(Script):
 
     #if first_setup:
     import time
-    time.sleep(5) 
+    time.sleep(5)
     self.update_zeppelin_interpreter()
-    
+
   def status(self, env):
     import status_params
-    env.set_params(status_params) 
-    
+    env.set_params(status_params)
+
     pid_file = glob.glob(status_params.zeppelin_pid_dir + '/zeppelin-'+status_params.zeppelin_user+'*.pid')[0]
-    check_process_status(pid_file)        
+    check_process_status(pid_file)
 
   def install_mvn_repo(self):
     #for centos/RHEL 6/7 maven repo needs to be installed
@@ -250,7 +255,7 @@ class Master(Script):
     import params
     import json,urllib,urllib2
     zeppelin_int_url='http://'+params.zeppelin_host+':'+str(params.zeppelin_port)+'/api/interpreter/setting/'
-    
+
     #fetch current interpreter settings for spark, hive, phoenix
     data = json.load(urllib2.urlopen(zeppelin_int_url))
     print data
@@ -261,7 +266,7 @@ class Master(Script):
         hivebody = body
       elif  body['group'] == 'phoenix':
         phoenixbody = body
-        
+
     #if hive installed, update hive settings and post to hive interpreter
     if (params.hive_server_host):
       hivebody['properties']['hive.hiveserver2.url']='jdbc:hive2://'+params.hive_server_host+':10000'
@@ -273,7 +278,7 @@ class Master(Script):
       self.post_request(zeppelin_int_url + phoenixbody['id'], phoenixbody)
 
   def post_request(self, url, body):
-    import json,urllib,urllib2  
+    import json,urllib,urllib2
     encoded_body=json.dumps(body)
     req = urllib2.Request(str(url),encoded_body)
     req.get_method = lambda: 'PUT'
@@ -282,9 +287,9 @@ class Master(Script):
     except urllib2.HTTPError, error:
         print 'Exception: ' + error.read()
 
-    jsonresp=json.loads(response.decode('utf-8'))  
+    jsonresp=json.loads(response.decode('utf-8'))
     print jsonresp['status']
-  
-        
+
+
 if __name__ == "__main__":
   Master().execute()


### PR DESCRIPTION
Changes:
- Remove trail spaces (automatically by IDE)
- Change default encoding to UTF-8 in package/scripts/master.py. This fixes install error on Ubuntu 14.
- Maven is required to build Ambari View for Zeppelin. Added this to README.