### PR TITLE
Fix the bug causing Zeppelin notebook installation/start failure

### DIFF
--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -193,7 +193,7 @@ class Master(Script):
             params.zeppelin_port) + '/api/interpreter/setting/'
 
         # fetch current interpreter settings for spark, hive, phoenix
-        data = json.load(urllib2.urlopen(zeppelin_int_url), timeout=60)
+        data = json.load(urllib2.urlopen(zeppelin_int_url, timeout=60))
         print data
         for body in data['body']:
             if body['group'] == 'spark':


### PR DESCRIPTION
- 'timeout' argument should be urlopen() but not json.load.

The error message solved:

  File "/var/lib/ambari-agent/cache/stacks/HDP/2.4/services/ZEPPELIN/package/scripts/master.py", line 196, in update_zeppelin_interpreter
    data = json.load(urllib2.urlopen(zeppelin_int_url), timeout=60)
  File "/usr/lib64/python2.7/json/__init__.py", line 290, in load
    **kw)
  File "/usr/lib64/python2.7/json/__init__.py", line 351, in loads
    return cls(encoding=encoding, **kw).decode(s)
TypeError: __init__() got an unexpected keyword argument 'timeout'