### PR TITLE
fixed Zeppelin starting/restarting complaint variable 'response' asig…

### DIFF
--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -222,12 +222,13 @@ class Master(Script):
         encoded_body = json.dumps(body)
         req = urllib2.Request(str(url), encoded_body)
         req.get_method = lambda: 'PUT'
+        jsonresp = dict(status=None)
         try:
             response = urllib2.urlopen(req, encoded_body).read()
+            jsonresp = json.loads(response.decode('utf-8'))
         except urllib2.HTTPError, error:
             print 'Exception: ' + error.read()
 
-        jsonresp = json.loads(response.decode('utf-8'))
         print jsonresp['status']
 
 


### PR DESCRIPTION
…ned before definition.

ENV: 
centos 7.1, python 2.7.5(system), ambari-2.2.2.0, HDP-2.4.2.0 
ERROR:

> UnboundLocalError: local variable 'response' referenced before assignment
